### PR TITLE
Dark theme compatibility

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -346,7 +346,8 @@ void MainWindow::addDataToConsole(QByteArray data, DataDirection dataDir)
                 lastWasHex = false;
             }
 
-            addTextToConsoleAndLogIfEnabled(QString(c), QColor(Qt::black));
+            QColor sysTextColor = ui->console->palette().color(QPalette::Text);
+            addTextToConsoleAndLogIfEnabled(QString(c), sysTextColor);
         }
         // Newline after showing send data
         if ((dataDir == DataSend)

--- a/src/version.h
+++ b/src/version.h
@@ -22,8 +22,8 @@
 #define VERSION_H
 
 #define APP_NAME "SimpleSerial"
-#define APP_VERSION "1.1.0"
-#define APP_YEAR "2024"
+#define APP_VERSION "1.1.1"
+#define APP_YEAR "2025"
 #define APP_YEAR_FROM "2017"
 
 #endif // VERSION_H


### PR DESCRIPTION
Console font color now grabbed from system theme settings.

Before
![image](https://github.com/user-attachments/assets/f67f10c3-ad1d-4226-89c2-baeedfa5240f)

After
![image](https://github.com/user-attachments/assets/f5b1f538-e958-47b1-98bd-6e8038cc51ef)
